### PR TITLE
s3 permissions for transformation and loading lammbdas

### DIFF
--- a/terraform/iam_ingestion.tf
+++ b/terraform/iam_ingestion.tf
@@ -54,12 +54,12 @@ resource "aws_iam_policy" "ingestion_lambda_s3_policy" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "lambda_cw_role_attachment" {
+resource "aws_iam_role_policy_attachment" "ingestion_lambda_cw_role_attachment" {
   role       = aws_iam_role.role_for_ingestion_lambda.name
   policy_arn = aws_iam_policy.cloudwatch_logs_policy_for_ingestion_lambda.arn
 }
 
-resource "aws_iam_role_policy_attachment" "lambda_s3_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "ingestion_lambda_s3_policy_attachment" {
   role       = aws_iam_role.role_for_ingestion_lambda.name
   policy_arn = aws_iam_policy.ingestion_lambda_s3_policy.arn
 }

--- a/terraform/iam_loading.tf
+++ b/terraform/iam_loading.tf
@@ -28,23 +28,20 @@ resource "aws_iam_role_policy_attachment" "loading_cw_policy_attachment" {
   role = aws_iam_role.role_for_warehouse_loading_lambda.name
 }
 
-# resource "aws_iam_policy" "warehouse_loading_lambda_s3_policy" {
-#   name        = "warehouse_loading_lambda_s3_policy"
-#   description = "Allows reading from tranformed data bucket and writing to ingestion data bucket"
-#   policy = jsonencode({
-#     Version = "2012-10-17",
-#     Statement = [
-#       {
-#         actions = "s3:GetObject",
-#         effect = "Allow",
-#         resources = "${aws_s3_bucket.transformed_data_bucket.arn}/*" # ??
-#       },
-#       {
-#         ######################## ToDo: this needs to be permission to write to warehouse db
-#         actions = "s3:PutObject",
-#         effect = "Allow",
-#         resources = "${aws_s3_bucket.ingestion_data_bucket.arn}/*",
-#       },
-#     ]
-#   })
-# }
+resource "aws_iam_policy" "warehouse_loading_lambda_s3_policy" {
+  name        = "warehouse_loading_lambda_s3_policy"
+  description = "Allows reading from tranformed data bucket."
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        actions = "s3:GetObject",
+        effect = "Allow",
+        resources = "${aws_s3_bucket.transformed_data_bucket.arn}/*" 
+      },
+      # {
+      #   ##### Possible permission to access the warehouse db on aws.
+      # },
+    ]
+  })
+}

--- a/terraform/iam_loading.tf
+++ b/terraform/iam_loading.tf
@@ -41,7 +41,12 @@ resource "aws_iam_policy" "warehouse_loading_lambda_s3_policy" {
       },
       # {
       #   ##### Possible permission to access the warehouse db on aws.
-      # },
+      # }
     ]
   })
+}
+
+resource "aws_iam_role_policy_attachment" "warehouse_loading_lambda_s3_policy_attachment" {
+  role       = aws_iam_role.role_for_warehouse_loading_lambda.name
+  policy_arn = aws_iam_policy.warehouse_loading_lambda_s3_policy.arn
 }

--- a/terraform/iam_transformation.tf
+++ b/terraform/iam_transformation.tf
@@ -28,3 +28,29 @@ resource "aws_iam_role_policy_attachment" "transformation_lambda_cw_policy_attac
   policy_arn = aws_iam_policy.cloudwatch_logs_policy_for_transformation_lambda.arn
   role = aws_iam_role.role_for_warehouse_transformation_lambda.name
 }
+
+resource "aws_iam_policy" "transformation_lambda_s3_policy" {
+  name        = "ingestion_lambda_s3_policy"
+  description = "Allows reading from  ingested data bucket and writing to transformed data bucket"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        actions = "s3:GetObject",
+        effect = "Allow",
+        resources = "${aws_s3_bucket.ingestion_data_bucket.arn}/*" 
+      },
+      {
+        actions = "s3:PutObject",
+        effect = "Allow",
+        resources = "${aws_s3_bucket.transformed_data_bucket.arn}/*",
+      },
+    ]
+  })
+}
+
+
+resource "aws_iam_role_policy_attachment" "transformation_lambda_s3_policy_attachment" {
+  role       = aws_iam_role.role_for_ingestion_lambda.name
+  policy_arn = aws_iam_policy.ingestion_lambda_s3_policy.arn
+}

--- a/terraform/iam_transformation.tf
+++ b/terraform/iam_transformation.tf
@@ -23,10 +23,9 @@ resource "aws_iam_policy" "cloudwatch_logs_policy_for_transformation_lambda" {
   })
 }
 
-
 resource "aws_iam_role_policy_attachment" "transformation_lambda_cw_policy_attachment" {
   policy_arn = aws_iam_policy.cloudwatch_logs_policy_for_transformation_lambda.arn
-  role = aws_iam_role.role_for_warehouse_transformation_lambda.name
+  role = aws_iam_role.role_for_transformation_lambda.name
 }
 
 resource "aws_iam_policy" "transformation_lambda_s3_policy" {
@@ -49,8 +48,7 @@ resource "aws_iam_policy" "transformation_lambda_s3_policy" {
   })
 }
 
-
 resource "aws_iam_role_policy_attachment" "transformation_lambda_s3_policy_attachment" {
-  role       = aws_iam_role.role_for_ingestion_lambda.name
-  policy_arn = aws_iam_policy.ingestion_lambda_s3_policy.arn
+  role       = aws_iam_role.role_for_transformation_lambda.name
+  policy_arn = aws_iam_policy.transformation_lambda_s3_policy.arn
 }


### PR DESCRIPTION
Added:

Get object and put object permissions created and attached to the transformation lambda. 

Created get object permission for the loading lambda. 

