### PR TITLE
complete format_dim_counterparty_util

### DIFF
--- a/src/transformation_lambda/format_dim_counterparty.py
+++ b/src/transformation_lambda/format_dim_counterparty.py
@@ -1,0 +1,57 @@
+import logging
+logger = logging.getLogger('MyLogger')
+logger.setLevel(logging.INFO)
+
+
+def format_dim_counterparty(table):
+    '''
+    argument:sales_order_table
+        type:dict
+            key: table name
+            value: updated content (list of dictionary)
+
+    return:
+        type: list of lists
+            for each row:
+                counterparty_id: int
+                counterparty_legal_name: str
+                counterparty_legal_address_line_1: str
+                counterparty_legal_address_line_2: str
+                counterparty_legal_district: str
+                counterparty_legal_city: str
+                counterparty_legal_postal_code: str
+                counterparty_legal_country: str
+                counterparty_legal_phone_number: str
+    raise:
+        RuntimeError
+        KeyError
+    '''
+
+    try:
+        # read counterparty table content from the ingestion lambda output
+        updpated_cp = table['counterparty']
+        address_lookup = table['address']
+        result = []
+        for c in updpated_cp:
+            # searching address from address_look_up_table
+            address = [r for r in address_lookup if r['address_id'] == c['legal_address_id']][0] # noqa E501
+            # formating the dim table
+            result.append({
+                'counterparty_id': c['legal_address_id'],
+                'counterparty_legal_name': c['counterparty_legal_name'],
+                'counterparty_legal_address_line_1': address['address_line_1'],
+                'counterparty_legal_address_line_2': address['address_line_2'],
+                'counterparty_legal_district': address['district'],
+                'counterparty_legal_city': address['city'],
+                'counterparty_legal_postal_code': address['postal_code'],
+                'counterparty_legal_country': address['country'],
+                'counterparty_legal_phone_number': address['phone']
+            })
+        return result
+
+    except KeyError as k:
+        logger.error(f'Error retrieving data, {k}')
+
+    except Exception as e:
+        logger.error(e)
+        raise RuntimeError

--- a/test/test_format_dim_counterparty.py
+++ b/test/test_format_dim_counterparty.py
@@ -1,0 +1,81 @@
+from src.transformation_lambda.format_dim_counterparty import format_dim_counterparty # noqa E501
+import pytest
+import logging
+
+test_table = {
+            "address": [{
+                "address_id": 1,
+                "address_line_1": "6826 Herzog Via",
+                "address_line_2": None,
+                "district": "Avon", "city":
+                "New Patienceburgh",
+                "postal_code": "28441",
+                "country": "Turkey",
+                "phone": "1803 637401",
+                "created_at": "2022-11-03T14:20:49.962",
+                "last_updated": "2022-11-03T14:20:49.962"
+            }, {
+                "address_id": 2,
+                "address_line_1": "179 Alexie Cliffs",
+                "address_line_2": None,
+                "district": None,
+                "city": "Aliso Viejo",
+                "postal_code": "99305-7380",
+                "country": "San Marino",
+                "phone": "9621 880720",
+                "created_at": "2022-11-03T14:20:49.962",
+                "last_updated": "2022-11-03T14:20:49.962"
+            }
+            ],
+
+            "counterparty": [{
+                "counterparty_id": 1,
+                "counterparty_legal_name": "Fahey and Sons",
+                "legal_address_id": 1,
+                "commercial_contact": "Micheal Toy",
+                "delivery_contact": "Mrs. Lucy Runolfsdottir",
+                "created_at": "2022-11-03T14:20:51.563",
+                "last_updated": "2022-11-03T14:20:51.563"
+                }]
+}
+
+
+def test_output_rows_has_correct_key_names():
+    result = format_dim_counterparty(test_table)
+    for row in result:
+        assert 'counterparty_id' in row
+        assert 'counterparty_legal_name' in row
+        assert 'counterparty_legal_address_line_1' in row
+        assert 'counterparty_legal_address_line_2' in row
+        assert 'counterparty_legal_district' in row
+        assert 'counterparty_legal_city' in row
+        assert 'counterparty_legal_postal_code' in row
+        assert 'counterparty_legal_country' in row
+        assert 'counterparty_legal_phone_number' in row
+        assert len(row) == 9
+
+
+def test_correct_output():
+    result = format_dim_counterparty(test_table)
+    assert len(result) == 1
+    assert {'counterparty_id': 1,
+            'counterparty_legal_name': "Fahey and Sons",
+            'counterparty_legal_address_line_1': "6826 Herzog Via",
+            'counterparty_legal_address_line_2': None,
+            'counterparty_legal_district': "Avon",
+            'counterparty_legal_city': "New Patienceburgh",
+            'counterparty_legal_postal_code': "28441",
+            'counterparty_legal_country': "Turkey",
+            'counterparty_legal_phone_number': "1803 637401", } in result
+
+
+def test_KeyError_happend_when_wrong_table_name(caplog):
+    wrong_table = {'staff': test_table['counterparty']}
+    with caplog.at_level(logging.ERROR):
+        format_dim_counterparty(wrong_table)
+        assert 'Error retrieving data' in caplog.text
+
+
+def test_RuntimeError_happend_when_wrong_input():
+    with pytest.raises(RuntimeError):
+        format_dim_counterparty(5)


### PR DESCRIPTION
completed the format_dim_counterparty_util which takes data from the ingestion bucket in the counterparty and address tables and outputs the data in a list of lists.